### PR TITLE
Start adding an ip package with interfaces common to both families

### DIFF
--- a/ip/address.go
+++ b/ip/address.go
@@ -1,0 +1,40 @@
+package ip
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"gopkg.in/addrs.v1/ipv4"
+	"gopkg.in/addrs.v1/ipv6"
+)
+
+// Address is the common interface implemented by both IPv4 and IPv6 addresses
+type Address interface {
+	String() string
+	ToNetIP() net.IP
+	NumBits() int
+}
+
+var _ Address = ipv4.Address{}
+var _ Address = ipv6.Address{}
+
+// AddressFromString returns an instance of an ipv4.Address or ipv6.Address
+func AddressFromString(address string) (Address, error) {
+	if strings.Contains(address, ":") {
+		return ipv6.AddressFromString(address)
+	}
+	return ipv4.AddressFromString(address)
+}
+
+// AddressFromNetIP returns an instance of an ipv4.Address or ipv6.Address
+func AddressFromNetIP(ip net.IP) (Address, error) {
+	switch len(ip) {
+	case net.IPv6len:
+		return ipv6.AddressFromNetIP(ip)
+	case net.IPv4len:
+		return ipv4.AddressFromNetIP(ip)
+	default:
+		return nil, fmt.Errorf("invalid net.IP of size %d", len(ip))
+	}
+}

--- a/ip/address_test.go
+++ b/ip/address_test.go
@@ -1,0 +1,48 @@
+package ip
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/addrs.v1/ipv4"
+	"gopkg.in/addrs.v1/ipv6"
+)
+
+func TestParseAddress(t *testing.T) {
+	t.Run("invalid", func(t *testing.T) {
+		_, err := AddressFromString("bogus")
+		assert.NotNil(t, err)
+	})
+	t.Run("v4", func(t *testing.T) {
+		a, err := AddressFromString("203.0.113.17")
+		assert.Nil(t, err)
+		assert.IsType(t, ipv4.Address{}, a)
+		assert.Equal(t, "203.0.113.17", a.String())
+	})
+	t.Run("v6", func(t *testing.T) {
+		a, err := AddressFromString("2001:db8::1")
+		assert.Nil(t, err)
+		assert.IsType(t, ipv6.Address{}, a)
+		assert.Equal(t, "2001:db8::1", a.String())
+	})
+}
+
+func TestAddressFromNetIP(t *testing.T) {
+	t.Run("invalid", func(t *testing.T) {
+		_, err := AddressFromNetIP(net.IP{})
+		assert.NotNil(t, err)
+	})
+	t.Run("v4", func(t *testing.T) {
+		a, err := AddressFromNetIP(net.IPv4(203, 0, 113, 29).To4())
+		assert.Nil(t, err)
+		assert.IsType(t, ipv4.Address{}, a)
+		assert.Equal(t, "203.0.113.29", a.String())
+	})
+	t.Run("v6", func(t *testing.T) {
+		a, err := AddressFromNetIP(net.ParseIP("2001:db8::1"))
+		assert.Nil(t, err)
+		assert.IsType(t, ipv6.Address{}, a)
+		assert.Equal(t, "2001:db8::1", a.String())
+	})
+}

--- a/ip/mask.go
+++ b/ip/mask.go
@@ -1,0 +1,36 @@
+package ip
+
+import (
+	"fmt"
+	"net"
+
+	"gopkg.in/addrs.v1/ipv4"
+	"gopkg.in/addrs.v1/ipv6"
+)
+
+// Mask is the common interface implemented by both IPv4 and IPv6 netmasks
+type Mask interface {
+	Length() int
+	String() string
+	ToNetIPMask() net.IPMask
+}
+
+var _ Mask = ipv4.Mask{}
+var _ Mask = ipv6.Mask{}
+
+func MaskFromNetIPMask(mask net.IPMask) (Mask, error) {
+	ones, bits := mask.Size()
+	if ones < 0 || bits < 0 {
+		return nil, fmt.Errorf("invalid net.IPMask /%d (%d bits)", ones, bits)
+	}
+	if ones > bits {
+		return nil, fmt.Errorf("invalid net.IPMask /%d (%d bits)", ones, bits)
+	}
+	switch bits {
+	case 8 * net.IPv6len:
+		return ipv6.MaskFromLength(ones)
+	case 8 * net.IPv4len:
+		return ipv4.MaskFromLength(ones)
+	}
+	return nil, fmt.Errorf("invalid net.IPMask size: %d bits", bits)
+}

--- a/ip/mask_test.go
+++ b/ip/mask_test.go
@@ -1,0 +1,47 @@
+package ip
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/addrs.v1/ipv4"
+	"gopkg.in/addrs.v1/ipv6"
+)
+
+func TestMaskFromNetIPMask(t *testing.T) {
+	t.Run("invalid", func(t *testing.T) {
+		m, err := MaskFromNetIPMask(net.IPMask{})
+		assert.NotNil(t, err)
+		assert.Nil(t, m)
+	})
+	t.Run("bad length", func(t *testing.T) {
+		m, err := MaskFromNetIPMask(net.CIDRMask(24, 31))
+		assert.NotNil(t, err)
+		assert.Nil(t, m)
+	})
+	t.Run("negative length", func(t *testing.T) {
+		m, err := MaskFromNetIPMask(net.CIDRMask(24, -1))
+		assert.NotNil(t, err)
+		assert.Nil(t, m)
+	})
+	t.Run("negative bits", func(t *testing.T) {
+		m, err := MaskFromNetIPMask(net.CIDRMask(-1, 32))
+		assert.NotNil(t, err)
+		assert.Nil(t, m)
+	})
+	t.Run("v4", func(t *testing.T) {
+		m, err := MaskFromNetIPMask(net.CIDRMask(24, 32))
+		assert.Nil(t, err)
+		assert.IsType(t, ipv4.Mask{}, m)
+		assert.Equal(t, 24, m.Length())
+		assert.Equal(t, "255.255.255.0", m.String())
+	})
+	t.Run("v6", func(t *testing.T) {
+		m, err := MaskFromNetIPMask(net.CIDRMask(64, 128))
+		assert.Nil(t, err)
+		assert.IsType(t, ipv6.Mask{}, m)
+		assert.Equal(t, 64, m.Length())
+		assert.Equal(t, "ffff:ffff:ffff:ffff::", m.String())
+	})
+}

--- a/ip/prefix.go
+++ b/ip/prefix.go
@@ -1,0 +1,59 @@
+package ip
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"gopkg.in/addrs.v1/ipv4"
+	"gopkg.in/addrs.v1/ipv6"
+)
+
+// Prefix is the common interface implemented by both IPv4 and IPv6 Prefix
+type Prefix interface {
+	Length() int
+	String() string
+	ToNetIPNet() *net.IPNet
+}
+
+var _ Prefix = ipv4.Prefix{}
+var _ Prefix = ipv6.Prefix{}
+
+func PrefixFromAddressMask(address Address, mask Mask) (Prefix, error) {
+	switch address := address.(type) {
+	case ipv6.Address:
+		mask, ok := mask.(ipv6.Mask)
+		if !ok {
+			return nil, fmt.Errorf("address family (ipv6) doesn't match the mask family")
+		}
+		return ipv6.PrefixFromAddressMask(address, mask), nil
+	case ipv4.Address:
+		mask, ok := mask.(ipv4.Mask)
+		if !ok {
+			return nil, fmt.Errorf("address family (ipv4) doesn't match the mask family")
+		}
+		return ipv4.PrefixFromAddressMask(address, mask), nil
+	}
+	return nil, fmt.Errorf("unknown address family")
+}
+
+func PrefixFromString(prefix string) (Prefix, error) {
+	if strings.Contains(prefix, ":") {
+		return ipv6.PrefixFromString(prefix)
+	}
+	return ipv4.PrefixFromString(prefix)
+}
+
+func PrefixFromNetIPNet(ipn *net.IPNet) (Prefix, error) {
+	if ipn == nil {
+		return nil, fmt.Errorf("cannot create Prefix from nil")
+	}
+	switch len(ipn.IP) {
+	case net.IPv6len:
+		return ipv6.PrefixFromNetIPNet(ipn)
+	case net.IPv4len:
+		return ipv4.PrefixFromNetIPNet(ipn)
+	default:
+		return nil, fmt.Errorf("invalid net.IPNet with IP of size %d", len(ipn.IP))
+	}
+}

--- a/ip/prefix_test.go
+++ b/ip/prefix_test.go
@@ -1,0 +1,103 @@
+package ip
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/addrs.v1/ipv4"
+	"gopkg.in/addrs.v1/ipv6"
+)
+
+func TestPrefixFromAddressMask(t *testing.T) {
+	t.Run("invalid", func(t *testing.T) {
+		_, err := PrefixFromAddressMask(nil, nil)
+		assert.NotNil(t, err)
+	})
+	t.Run("nil address", func(t *testing.T) {
+		var a Address
+		m, _ := ipv6.MaskFromLength(24)
+		_, err := PrefixFromAddressMask(a, m)
+		assert.NotNil(t, err)
+	})
+	t.Run("nil mask", func(t *testing.T) {
+		a, _ := ipv4.AddressFromString("203.0.113.17")
+		var m Mask
+		_, err := PrefixFromAddressMask(a, m)
+		assert.NotNil(t, err)
+	})
+	t.Run("nil nil", func(t *testing.T) {
+		var a Address
+		var m Mask
+		_, err := PrefixFromAddressMask(a, m)
+		assert.NotNil(t, err)
+	})
+	t.Run("v4/6", func(t *testing.T) {
+		a, _ := ipv4.AddressFromString("203.0.113.17")
+		m, _ := ipv6.MaskFromLength(24)
+		_, err := PrefixFromAddressMask(a, m)
+		assert.NotNil(t, err)
+	})
+	t.Run("v6/4", func(t *testing.T) {
+		a, _ := ipv6.AddressFromString("2001:db8::1")
+		m, _ := ipv4.MaskFromLength(24)
+		_, err := PrefixFromAddressMask(a, m)
+		assert.NotNil(t, err)
+	})
+	t.Run("v4", func(t *testing.T) {
+		a, _ := ipv4.AddressFromString("203.0.113.17")
+		m, _ := ipv4.MaskFromLength(24)
+		p, err := PrefixFromAddressMask(a, m)
+		assert.Nil(t, err)
+		assert.IsType(t, ipv4.Prefix{}, p)
+		assert.Equal(t, "203.0.113.17/24", p.String())
+	})
+	t.Run("v6", func(t *testing.T) {
+		a, _ := ipv6.AddressFromString("2001:db8::1")
+		m, _ := ipv6.MaskFromLength(64)
+		p, err := PrefixFromAddressMask(a, m)
+		assert.Nil(t, err)
+		assert.IsType(t, ipv6.Prefix{}, p)
+		assert.Equal(t, "2001:db8::1/64", p.String())
+	})
+}
+
+func TestParsePrefix(t *testing.T) {
+	t.Run("invalid", func(t *testing.T) {
+		_, err := PrefixFromString("bogus")
+		assert.NotNil(t, err)
+	})
+	t.Run("v4", func(t *testing.T) {
+		p, err := PrefixFromString("203.0.113.17/24")
+		assert.Nil(t, err)
+		assert.IsType(t, ipv4.Prefix{}, p)
+		assert.Equal(t, "203.0.113.17/24", p.String())
+	})
+	t.Run("v6", func(t *testing.T) {
+		p, err := PrefixFromString("2001:db8::1/64")
+		assert.Nil(t, err)
+		assert.IsType(t, ipv6.Prefix{}, p)
+		assert.Equal(t, "2001:db8::1/64", p.String())
+	})
+}
+
+func TestPrefixFromNetIP(t *testing.T) {
+	t.Run("invalid", func(t *testing.T) {
+		_, err := PrefixFromNetIPNet(&net.IPNet{})
+		assert.NotNil(t, err)
+	})
+	t.Run("v4", func(t *testing.T) {
+		netP, _ := ipv4.PrefixFromString("203.0.113.29/24")
+		p, err := PrefixFromNetIPNet(netP.ToNetIPNet())
+		assert.Nil(t, err)
+		assert.IsType(t, ipv4.Prefix{}, p)
+		assert.Equal(t, "203.0.113.29/24", p.String())
+	})
+	t.Run("v6", func(t *testing.T) {
+		netP, _ := ipv6.PrefixFromString("2001:db8::1/64")
+		p, err := PrefixFromNetIPNet(netP.ToNetIPNet())
+		assert.Nil(t, err)
+		assert.IsType(t, ipv6.Prefix{}, p)
+		assert.Equal(t, "2001:db8::1/64", p.String())
+	})
+}

--- a/ip/range.go
+++ b/ip/range.go
@@ -1,0 +1,36 @@
+package ip
+
+import (
+	"fmt"
+
+	"gopkg.in/addrs.v1/ipv4"
+	"gopkg.in/addrs.v1/ipv6"
+)
+
+// Range is the common interface implemented by both IPv4 and IPv6 Range
+type Range interface {
+	String() string
+}
+
+var _ Range = ipv4.Range{}
+var _ Range = ipv6.Range{}
+
+func RangeFromAddresses(first, last Address) (Range, bool, error) {
+	switch first := first.(type) {
+	case ipv6.Address:
+		last, ok := last.(ipv6.Address)
+		if !ok {
+			return nil, false, fmt.Errorf("first address family (ipv6) doesn't match the last family")
+		}
+		r, empty := ipv6.RangeFromAddresses(first, last)
+		return r, empty, nil
+	case ipv4.Address:
+		last, ok := last.(ipv4.Address)
+		if !ok {
+			return nil, false, fmt.Errorf("first address family (ipv4) doesn't match the last family")
+		}
+		r, empty := ipv4.RangeFromAddresses(first, last)
+		return r, empty, nil
+	}
+	return nil, false, fmt.Errorf("unknown first address family")
+}

--- a/ip/range_test.go
+++ b/ip/range_test.go
@@ -1,0 +1,77 @@
+package ip
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/addrs.v1/ipv4"
+	"gopkg.in/addrs.v1/ipv6"
+)
+
+func TestRangeFromAddresses(t *testing.T) {
+	t.Run("invalid", func(t *testing.T) {
+		_, _, err := RangeFromAddresses(nil, nil)
+		assert.NotNil(t, err)
+	})
+	t.Run("nil address", func(t *testing.T) {
+		var a1 Address
+		a2, _ := ipv6.AddressFromString("2001:db8::1")
+		_, _, err := RangeFromAddresses(a1, a2)
+		assert.NotNil(t, err)
+	})
+	t.Run("nil mask", func(t *testing.T) {
+		a1, _ := ipv4.AddressFromString("203.0.113.17")
+		var a2 Address
+		_, _, err := RangeFromAddresses(a1, a2)
+		assert.NotNil(t, err)
+	})
+	t.Run("nil nil", func(t *testing.T) {
+		var a1, a2 Address
+		_, _, err := RangeFromAddresses(a1, a2)
+		assert.NotNil(t, err)
+	})
+	t.Run("v4/6", func(t *testing.T) {
+		a1, _ := ipv4.AddressFromString("203.0.113.17")
+		a2, _ := ipv6.AddressFromString("2001:db8::1")
+		_, _, err := RangeFromAddresses(a1, a2)
+		assert.NotNil(t, err)
+	})
+	t.Run("v6/4", func(t *testing.T) {
+		a1, _ := ipv6.AddressFromString("2001:db8::1")
+		a2, _ := ipv4.AddressFromString("203.0.113.17")
+		_, _, err := RangeFromAddresses(a1, a2)
+		assert.NotNil(t, err)
+	})
+	t.Run("v4", func(t *testing.T) {
+		a1, _ := ipv4.AddressFromString("203.0.113.17")
+		a2, _ := ipv4.AddressFromString("203.0.113.27")
+		r, empty, err := RangeFromAddresses(a1, a2)
+		assert.Nil(t, err)
+		assert.False(t, empty)
+		assert.IsType(t, ipv4.Range{}, r)
+		assert.Equal(t, "[203.0.113.17,203.0.113.27]", r.String())
+	})
+	t.Run("v6", func(t *testing.T) {
+		a1, _ := ipv6.AddressFromString("2001:db8::1")
+		a2, _ := ipv6.AddressFromString("2001:db8::101")
+		r, empty, err := RangeFromAddresses(a1, a2)
+		assert.Nil(t, err)
+		assert.False(t, empty)
+		assert.IsType(t, ipv6.Range{}, r)
+		assert.Equal(t, "[2001:db8::1,2001:db8::101]", r.String())
+	})
+	t.Run("v4 empty", func(t *testing.T) {
+		a1, _ := ipv4.AddressFromString("203.0.113.27")
+		a2, _ := ipv4.AddressFromString("203.0.113.17")
+		_, empty, err := RangeFromAddresses(a1, a2)
+		assert.Nil(t, err)
+		assert.True(t, empty)
+	})
+	t.Run("v6 empty", func(t *testing.T) {
+		a1, _ := ipv6.AddressFromString("2001:db8::101")
+		a2, _ := ipv6.AddressFromString("2001:db8::1")
+		_, empty, err := RangeFromAddresses(a1, a2)
+		assert.Nil(t, err)
+		assert.True(t, empty)
+	})
+}


### PR DESCRIPTION
For example, an ip.Address has the methods implemented by both ipv4.Address and ipv6.Address